### PR TITLE
Update routes for react-router-dom v6

### DIFF
--- a/frontend/src/components/Main.tsx
+++ b/frontend/src/components/Main.tsx
@@ -190,12 +190,8 @@ function Main({ width }: WithWidth): React.ReactElement {
           <div className={classes.appBarSpacer} />
           <Container maxWidth="sm" className={classes.container}>
             <Routes>
-              <Route path="/">
-                <PrintStatus />
-              </Route>
-              <Route path="/files">
-                <FileList />
-              </Route>
+              <Route path="/" element={<PrintStatus />} />
+              <Route path="/files" element={<FileList />} />
             </Routes>
           </Container>
         </main>


### PR DESCRIPTION
With [changes introduced upstream](https://github.com/luizribeiro/mariner/commit/cd396cf932eaae2fa10695ab1488d8e4e2d93337), it is no longer possible to run a dev version of frontend, because `react-router-dom` was upgraded from v5 to v6 which has some groundbreaking changes. Here is a [migration guide](https://github.com/remix-run/react-router/blob/f59ee5488bc343cf3c957b7e0cc395ef5eb572d2/docs/advanced-guides/migrating-5-to-6.md#relative-routes-and-links).

This allows frontend to at least run.